### PR TITLE
Updated  to take into account symbol names, not just paths.

### DIFF
--- a/src/styleguide2asketch.js
+++ b/src/styleguide2asketch.js
@@ -11,7 +11,7 @@ function bemClassToText(bemClass) {
 function buildSymbolNameFromBEM(classes) {
   const mainClass = classes.shift();
   const subClasses = Array.from(classes)
-    .map(clsName => clsName.replace(mainClass, '').replace('--', ''))
+    .map(clsName => clsName.replace(mainClass, '').replace('--', '').replace(/_/g, ' '))
     .join(' ');
 
   return bemClassToText(mainClass) + '/' + (subClasses || '_default_');

--- a/src/styleguide2asketch.js
+++ b/src/styleguide2asketch.js
@@ -1,8 +1,8 @@
-import Document from '@brainly/html-sketchapp/html2asketch/document.js';
-import Page from '@brainly/html-sketchapp/html2asketch/page.js';
-import Text from '@brainly/html-sketchapp/html2asketch/text.js';
-import SymbolMaster from '@brainly/html-sketchapp/html2asketch/symbolMaster.js';
-import nodeToSketchLayers from '@brainly/html-sketchapp/html2asketch/nodeToSketchLayers.js';
+import Document from '@brainly/html-sketchapp/html2asketch/document';
+import Page from '@brainly/html-sketchapp/html2asketch/page';
+import Text from '@brainly/html-sketchapp/html2asketch/text';
+import SymbolMaster from '@brainly/html-sketchapp/html2asketch/symbolMaster';
+import nodeToSketchLayers from '@brainly/html-sketchapp/html2asketch/nodeToSketchLayers';
 
 function bemClassToText(bemClass) {
   return bemClass.replace('sg-', '').replace('-', ' ');

--- a/src/styleguide2asketch.js
+++ b/src/styleguide2asketch.js
@@ -11,7 +11,7 @@ function bemClassToText(bemClass) {
 function buildSymbolNameFromBEM(classes) {
   const mainClass = classes.shift();
   const subClasses = Array.from(classes)
-    .map(clsName => clsName.replace(mainClass, '').replace('--', '').replace(/_/g, ' '))
+    .map(clsName => clsName.replace(mainClass, '/').replace('--', '').replace(/_/g, ' '))
     .join(' ');
 
   return bemClassToText(mainClass) + '/' + (subClasses || '_default_');


### PR DESCRIPTION
BEM structure now works as `class="sg-Main sg-Main--Sub1 sg-Main--Sub2 sg-Main--Name_Surname"` which outputs to a `Main/Sub1/Sub2/Name_Surname` Sketch symbol structure. This makes complex Symbol structures easier to follow and maintain and inlines the BEM structure to how Symbols are usually created in Sketch.