### PR TITLE
Add smart layout to symbols

### DIFF
--- a/src/styleguide2asketch.js
+++ b/src/styleguide2asketch.js
@@ -70,6 +70,10 @@ export function getASketchPage() {
               layer.setHasClippingMask(true);
             }
 
+            if (symbol._name.startsWith('Label/')) {
+              symbol.setGroupLayout(SMART_LAYOUT.HORIZONTALLY_CENTER);
+            }
+
             // eslint-disable-next-line max-len
             if (symbol._name.startsWith('Label/') && layer instanceof SVG) {
               const type = node.children[0].id;


### PR DESCRIPTION
- handle label's with after updating its text content.

before:
<img width="168" alt="Screenshot 2020-01-03 at 09 35 55" src="https://user-images.githubusercontent.com/1231144/71714067-9acf8d00-2e0c-11ea-9ba2-7992f4809ac6.png">
after:
<img width="173" alt="Screenshot 2020-01-03 at 09 35 42" src="https://user-images.githubusercontent.com/1231144/71714066-9a36f680-2e0c-11ea-9411-2997ecce295f.png">

